### PR TITLE
[outlineOTF] correctly set IBM's openTypeOS2FamilyClass

### DIFF
--- a/Lib/ufo2ft/outlineOTF.py
+++ b/Lib/ufo2ft/outlineOTF.py
@@ -367,7 +367,9 @@ class OutlineCompiler(object):
             v = 0
         os2.yStrikeoutPosition = _roundInt(v)
         # family class
-        os2.sFamilyClass = 0 # XXX not sure how to create the appropriate value
+        ibmFontClass, ibmFontSubclass = getAttrWithFallback(
+            font.info, "openTypeOS2FamilyClass")
+        os2.sFamilyClass = (ibmFontClass << 8) + ibmFontSubclass
         # panose
         data = getAttrWithFallback(font.info, "openTypeOS2Panose")
         panose = Panose()


### PR DESCRIPTION
The OS2.sFamilyClass is a short int comprised of two bytes: the high byte
represents the "font class", the low byte the "font subclass".