### PR TITLE
[outlineOTF] don't write typographic (sub)family names if == legacy ones

### DIFF
--- a/Lib/ufo2ft/outlineOTF.py
+++ b/Lib/ufo2ft/outlineOTF.py
@@ -213,22 +213,35 @@ class OutlineCompiler(object):
         """
 
         font = self.ufo
+
+        subfamilyName = font.info.styleMapStyleName.title()
+
+        # If name ID 2 is "Regular", it can be omitted from name ID 4
+        fullName = font.info.styleMapFamilyName
+        if subfamilyName != "Regular":
+            fullName += " %s" % subfamilyName
+
         nameVals = {
             "0": font.info.copyright,
             "1": font.info.styleMapFamilyName,
-            "2": font.info.styleMapStyleName.title(),
+            "2": subfamilyName,
             "3": font.info.openTypeNameUniqueID,
-            "4": "%s %s" % (font.info.familyName, font.info.styleName),
+            "4": fullName,
             "5": font.info.openTypeNameVersion,
             "6": font.info.postscriptFontName,
             "7": font.info.trademark,
+            "8": font.info.openTypeNameManufacturer,
             "9": font.info.openTypeNameDesigner,
             "11": font.info.openTypeNameManufacturerURL,
             "12": font.info.openTypeNameDesignerURL,
             "13": font.info.openTypeNameLicense,
-            "14": font.info.openTypeNameLicenseURL,
-            "16": font.info.openTypeNamePreferredFamilyName,
-            "17": font.info.openTypeNamePreferredSubfamilyName}
+            "14": font.info.openTypeNameLicenseURL}
+
+        # don't add typographic names if they are the same as the legacy ones
+        if nameVals["1"] != font.info.openTypeNamePreferredFamilyName:
+            nameVals["16"] = font.info.openTypeNamePreferredFamilyName
+        if nameVals["2"] != font.info.openTypeNamePreferredSubfamilyName:
+            nameVals["17"] = font.info.openTypeNamePreferredSubfamilyName
 
         self.otf["name"] = name = newTable("name")
         name.names = []


### PR DESCRIPTION
From "Name IDs" section of https://www.microsoft.com/typography/otspec/name.htm:

> If name ID 16 is absent, then name ID 1 is considered to be the typographic family name.

similarly, for ID 17:
> If it is absent, then name ID 2 is considered to be the typographic subfamily name.

This means there's no need to add name ID 16 and 17 (the so-called "typographic" names) if they match the old, four-style-only names (ID 1 and 2).

Furthermore, when name ID 2 is "Regular", then the latter is usually omitted from the Full Name (name ID 4).