### PR TITLE
extend kern feature writer to support MMK and public.kern formats (WIP)

### DIFF
--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -1,120 +1,107 @@
 from __future__ import print_function, division, absolute_import, unicode_literals
-from feaTools import parser
-from feaTools.writers.baseWriter import AbstractFeatureWriter
 
 
-class KernFeatureWriter(AbstractFeatureWriter):
-    """Generates a kerning feature based on glyph class definitions.
+# UFO3 kerning class prefixes
+UFO3_PREFIX_1 = "public.kern1."
+UFO3_PREFIX_2 = "public.kern2."
+UFO3_PREFIX_LENGTH = len(UFO3_PREFIX_1)
+# Metrics Machine prefixes
+MMK_PREFIX_L = "@MMK_L_"
+MMK_PREFIX_R = "@MMK_R_"
+# common kerning class suffixes
+SUFFIX_L = ("_1ST", "_L", "_LEFT")
+SUFFIX_R = ("_2ND", "_R", "_RIGHT")
+# common kerning class prefixes
+ANY_KERN_PREFIX = (("@_",) + (MMK_PREFIX_L, MMK_PREFIX_R) +
+                   (UFO3_PREFIX_1, UFO3_PREFIX_2))
 
-    Uses the kerning rules contained in an RFont's kerning attribute, as well as
-    glyph classes from parsed OTF text. Class-based rules are set based on the
-    existing rules for their key glyphs.
+
+# class KernFeatureWriter(AbstractFeatureWriter):
+class KernFeatureWriter(object):
+    """Generates a kerning feature based on groups definitions and kerning
+    rules contained in font.
     """
 
     def __init__(self, font):
-        self.kerning = font.kerning
-        self.groups = font.groups
-        self.leftClasses = []
-        self.rightClasses = []
-        self.classSizes = {}
-        parser.parseFeatures(self, font.features.text)
+        # build dict of kerning groups from font.groups
+        self.kerningGroups = {}
+        for key, members in sorted(font.groups.items()):
+            if not key.startswith(ANY_KERN_PREFIX):
+                continue
+            key = self._makeFeaClassName(key)
+            self.kerningGroups[key] = members
 
-    def classDefinition(self, name, contents):
-        """Store a class definition as either a left- or right-hand class."""
+        # build dicts of kerning pairs from font.kerning
+        self.glyphPairKerning = {}
+        self.leftClassKerning = {}
+        self.rightClassKerning = {}
+        self.classPairKerning = {}
+        for (left, right), val in sorted(font.kerning.items()):
+            leftIsClass = left.startswith(ANY_KERN_PREFIX)
+            rightIsClass = right.startswith(ANY_KERN_PREFIX)
 
-        if not name.startswith("@_"):
-            return
-        info = (name, contents)
-        if name.endswith("_L"):
-            self.leftClasses.append(info)
-        elif name.endswith("_R"):
-            self.rightClasses.append(info)
-        self.classSizes[name] = len(contents)
+            if leftIsClass:
+                left = self._makeFeaClassName(left)
+
+            if rightIsClass:
+                right = self._makeFeaClassName(right)
+
+            if leftIsClass:
+                if rightIsClass:
+                    self.classPairKerning[left, right] = val
+                else:
+                    self.leftClassKerning[left, right] = val
+            elif rightIsClass:
+                self.rightClassKerning[left, right] = val
+            else:
+                self.glyphPairKerning[left, right] = val
 
     def _addGlyphClasses(self, lines):
         """Add glyph classes for the input font's groups."""
 
-        for key, members in self.groups.items():
-            lines.append("%s = [%s];" % (key, " ".join(members)))
+        for key, members in sorted(self.kerningGroups.items()):
+            lines.append("    %s = [%s];" % (key, " ".join(members)))
 
-    def _addKerning(self, lines, kerning=None, enum=False):
+    def _addKerning(self, lines, kerning, enum=False):
         """Add kerning rules for a mapping of pairs to values."""
 
-        usingFontKerning = False
-        if kerning is None:
-            usingFontKerning = True
-            kerning = self.kerning
-
         enum = "enum " if enum else ""
-
         for (left, right), val in sorted(kerning.items()):
-            if usingFontKerning:
-                leftIsClass = left.startswith("@")
-                rightIsClass = right.startswith("@")
-                if leftIsClass:
-                    if rightIsClass:
-                        self.classPairKerning[left, right] = val
-                    else:
-                        self.leftClassKerning[left, right] = val
-                    continue
-                elif rightIsClass:
-                    self.rightClassKerning[left, right] = val
-                    continue
-
             lines.append("    %spos %s %s %d;" % (enum, left, right, val))
-
-    def _collectClassKerning(self):
-        """Set up collections of different rule types."""
-
-        self.leftClassKerning = {}
-        self.rightClassKerning = {}
-        self.classPairKerning = {}
-
-        for leftName, leftContents in self.leftClasses:
-            leftKey = leftContents[0]
-
-            # collect rules with two classes
-            for rightName, rightContents in self.rightClasses:
-                rightKey = rightContents[0]
-                pair = leftKey, rightKey
-                kerningVal = self.kerning[pair]
-                if kerningVal is None:
-                    continue
-                self.classPairKerning[leftName, rightName] = kerningVal
-                self.kerning.remove(pair)
-
-            # collect rules with left class and right glyph
-            for pair, kerningVal in self.kerning.getLeft(leftKey):
-                self.leftClassKerning[leftName, pair[1]] = kerningVal
-                self.kerning.remove(pair)
-
-        # collect rules with left glyph and right class
-        for rightName, rightContents in self.rightClasses:
-            rightKey = rightContents[0]
-            for pair, kerningVal in self.kerning.getRight(rightKey):
-                self.rightClassKerning[pair[0], rightName] = kerningVal
-                self.kerning.remove(pair)
 
     def write(self, linesep="\n"):
         """Write kern feature."""
 
-        self._collectClassKerning()
+        if not any([self.glyphPairKerning, self.leftClassKerning,
+                    self.rightClassKerning, self.classPairKerning]):
+            # no kerning pairs, return empty
+            return ""
 
-        # write the glyph classes
         lines = []
+        lines.append("feature kern {")
         self._addGlyphClasses(lines)
         lines.append("")
-
-        # write the feature
-        lines.append("feature kern {")
-        self._addKerning(lines)
-        lines.append("    subtable;")
-        self._addKerning(lines, self.leftClassKerning, enum=True)
-        lines.append("    subtable;")
-        self._addKerning(lines, self.rightClassKerning, enum=True)
-        lines.append("    subtable;")
-        self._addKerning(lines, self.classPairKerning)
+        self._addKerning(lines, self.glyphPairKerning)
+        if self.leftClassKerning:
+            lines.append("")
+            self._addKerning(lines, self.leftClassKerning, enum=True)
+        if self.rightClassKerning:
+            lines.append("")
+            self._addKerning(lines, self.rightClassKerning, enum=True)
+        if self.classPairKerning:
+            lines.append("")
+            self._addKerning(lines, self.classPairKerning)
         lines.append("} kern;")
 
-        # return the feature, unless it's empty
-        return "" if len([ln for ln in lines if ln]) == 5 else linesep.join(lines)
+        return linesep.join(lines)
+
+    @staticmethod
+    def _makeFeaClassName(name):
+        """ Strip 'public.kern1.', 'public.kern2.' prefixes and add '@' if
+        not already there.
+        """
+        if name.startswith((UFO3_PREFIX_1, UFO3_PREFIX_2)):
+            name = name[UFO3_PREFIX_LENGTH:]
+        if not name.startswith("@"):
+            name = "@" + name
+        return name


### PR DESCRIPTION
this is an alternative way to accomplish the same thing that James did in https://github.com/jamesgk/ufo2ft/pull/6.

I did this while I was trying to use ufo2ft for https://github.com/daltonmaag/scope-one project. Eventually, however, we ended up using ufo2fdk's (python3-ufo3) kernFeatureWriter instead of ufo2ft.

We didn't use the ufoLib from robofab/master, but the standalone ufoLib (i.e. the one extracted from robofab's ufo3k branch) and defcon (python3-ufo3, based on Adrien's trufont forks).

Despite our source UFO was format 2 (with `@MMK_`-style kerning groups), when it is loaded in ufoLib, the kerning is internally converted by ufoLib to a UFO3-style `public.kern{1,2}` kerning. 

All our kerning groups were stored in the font's groups.plist, so we didn't find a use for feaTools' parseFeatures (which is used in James' version to parse glyph classes from the feature file itself). That's why I decided to remove that dependency.

I'm posting this here so we can discuss how and whether we could integrate the different approaches.

Let me know what you think. Maybe next week I'll try to elaborate a bit better on this.
Cheers,

Cosimo
