### PR TITLE
[outlineOTF] Use just coords for glyph lsb in hmtx

### DIFF
--- a/Lib/ufo2ft/outlineOTF.py
+++ b/Lib/ufo2ft/outlineOTF.py
@@ -6,12 +6,12 @@ import time
 
 from fontTools.ttLib import TTFont, newTable
 from fontTools.cffLib import TopDictIndex, TopDict, CharStrings, SubrsIndex, GlobalSubrsIndex, PrivateDict, IndexedStrings
+from fontTools.pens.boundsPen import BoundsPen, ControlBoundsPen
 from fontTools.pens.t2CharStringPen import T2CharStringPen
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib.tables.O_S_2f_2 import Panose
 from fontTools.ttLib.tables._h_e_a_d import mac_epoch_diff
 from fontTools.ttLib.tables._n_a_m_e import NameRecord
-from robofab.pens.boundsPen import ControlBoundsPen
 
 from ufo2ft.fontInfoData import getFontBounds, getAttrWithFallback, dateStringToTimeValue, dateStringForNow, intListToNum, normalizeStringForPostscript
 
@@ -505,7 +505,7 @@ class OutlineCompiler(object):
             if len(glyph) or len(glyph.components):
                 # lsb should be consistent with glyf xMin, which is just
                 # minimum x for coordinate data
-                pen = ControlBoundsPen(self.ufo)
+                pen = ControlBoundsPen(self.ufo, ignoreSinglePoints=True)
                 glyph.draw(pen)
                 left, _, _, _ = pen.bounds
             if left is None:
@@ -881,7 +881,6 @@ class StubGlyph(object):
         pen.closePath()
 
     def _get_bounds(self):
-        from fontTools.pens.boundsPen import BoundsPen
         pen = BoundsPen(None)
         self.draw(pen)
         return pen.bounds

--- a/Lib/ufo2ft/outlineOTF.py
+++ b/Lib/ufo2ft/outlineOTF.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, division, absolute_import, unicode_literals
 from fontTools.misc.py23 import tounicode
+
+import math
 import time
 
 from fontTools.ttLib import TTFont, newTable
@@ -9,6 +11,7 @@ from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib.tables.O_S_2f_2 import Panose
 from fontTools.ttLib.tables._h_e_a_d import mac_epoch_diff
 from fontTools.ttLib.tables._n_a_m_e import NameRecord
+from robofab.pens.boundsPen import ControlBoundsPen
 
 from ufo2ft.fontInfoData import getFontBounds, getAttrWithFallback, dateStringToTimeValue, dateStringForNow, intListToNum, normalizeStringForPostscript
 
@@ -493,16 +496,22 @@ class OutlineCompiler(object):
         may override or supplement this method to handle the
         table creation in a different way if desired.
         """
+
         self.otf["hmtx"] = hmtx = newTable("hmtx")
         hmtx.metrics = {}
         for glyphName, glyph in self.allGlyphs.items():
             width = glyph.width
             left = 0
             if len(glyph) or len(glyph.components):
-                left = glyph.leftMargin
+                # lsb should be consistent with glyf xMin, which is just
+                # minimum x for coordinate data
+                pen = ControlBoundsPen(self.ufo)
+                glyph.draw(pen)
+                left, _, _, _ = pen.bounds
             if left is None:
                 left = 0
-            hmtx[glyphName] = (_roundInt(width), _roundInt(left))
+            # take floor of lsb/xMin, as fontTools does with min bounds
+            hmtx[glyphName] = (_roundInt(width), int(math.floor(left)))
 
     def setupTable_hhea(self):
         """


### PR DESCRIPTION
I think this is correct, given that FontTools expects it; hmtx lsb values are compared with their respective glyphs' xMin values, which are calculated using just glyph coordinates. See:

https://github.com/behdad/fonttools/blob/a7aef4769558bbd829a2453f9579497d9b0297bb/Lib/fontTools/ttLib/tables/_m_a_x_p.py#L80
https://github.com/behdad/fonttools/blob/738866492ddfa98d75c9f5f399c662d9f958dd9b/Lib/fontTools/ttLib/tables/_g_l_y_f.py#L704

The other question is of the head table xMin/xMax/yMin/yMax values (and maybe others), should they also follow this rule? I'm not sure.

@behdad @adrientetar @anthrotype etc. can someone confirm this is the correct thing to be doing?