### PR TITLE
Kern feature gen improvements

### DIFF
--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -184,6 +184,11 @@ class KernFeatureWriter(AbstractFeatureWriter):
     def write(self, linesep="\n"):
         """Write kern feature."""
 
+        if not any([self.glyphPairKerning, self.leftClassKerning,
+                    self.rightClassKerning, self.classPairKerning]):
+            # no kerning pairs, don't write empty feature
+            return ""
+
         self._collectFeaClassKerning()
         self._collectUfoKerning()
         self._collectUfoGroups()
@@ -197,13 +202,15 @@ class KernFeatureWriter(AbstractFeatureWriter):
         # write the feature
         lines.append("feature kern {")
         self._addKerning(lines, self.glyphPairKerning)
-        lines.append("    subtable;")
-        self._addKerning(lines, self.leftClassKerning, enum=True)
-        lines.append("    subtable;")
-        self._addKerning(lines, self.rightClassKerning, enum=True)
-        lines.append("    subtable;")
-        self._addKerning(lines, self.classPairKerning)
+        if self.leftClassKerning:
+            lines.append("    subtable;")
+            self._addKerning(lines, self.leftClassKerning, enum=True)
+        if self.leftClassKerning:
+            lines.append("    subtable;")
+            self._addKerning(lines, self.rightClassKerning, enum=True)
+        if self.leftClassKerning:
+            lines.append("    subtable;")
+            self._addKerning(lines, self.classPairKerning)
         lines.append("} kern;")
 
-        # return the feature, unless it's empty
-        return "" if len([ln for ln in lines if ln]) == 5 else linesep.join(lines)
+        return linesep.join(lines)

--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -239,13 +239,13 @@ class KernFeatureWriter(AbstractFeatureWriter):
         "A-Za-z0-9._", and isn't already defined.
         """
 
-        if not name.startswith("@"):
-            name = "@" + name
-        name = re.sub(r"[^A-Za-z0-9._]", r"", name)
+        name = "@%s" % re.sub(r"[^A-Za-z0-9._]", r"", name)
         existingClassNames = (
             self.leftFeaClasses.keys() + self.rightFeaClasses.keys() +
             self.leftUfoClasses.keys() + self.rightUfoClasses.keys())
-        if name in existingClassNames:
-            raise ValueError('New glyph class name "%s" (from UFO groups) '
-                             'is the name of an existing class.')
+        i = 1
+        origName = name
+        while name in existingClassNames:
+            name = "%s_%d" % (origName, i)
+            i += 1
         return name

--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -25,6 +25,7 @@ class KernFeatureWriter(AbstractFeatureWriter):
     def __init__(self, font):
         self.kerning = font.kerning
         self.groups = font.groups
+        self.featxt = font.features.text
 
         # kerning classes found in existing OTF syntax and UFO groups
         self.leftFeaClasses = {}
@@ -49,16 +50,16 @@ class KernFeatureWriter(AbstractFeatureWriter):
     def write(self, linesep="\n"):
         """Write kern feature."""
 
-        if not any([self.glyphPairKerning, self.leftClassKerning,
-                    self.rightClassKerning, self.classPairKerning]):
-            # no kerning pairs, don't write empty feature
-            return ""
-
         self._collectFeaClasses()
         self._collectFeaClassKerning()
         self._collectUfoClasses()
         self._collectUfoKerning()
         self._removeConflictingKerningRules()
+
+        if not any([self.glyphPairKerning, self.leftClassKerning,
+                    self.rightClassKerning, self.classPairKerning]):
+            # no kerning pairs, don't write empty feature
+            return ""
 
         # write the glyph classes
         lines = []
@@ -71,10 +72,10 @@ class KernFeatureWriter(AbstractFeatureWriter):
         if self.leftClassKerning:
             lines.append("    subtable;")
             self._addKerning(lines, self.leftClassKerning, enum=True)
-        if self.leftClassKerning:
+        if self.rightClassKerning:
             lines.append("    subtable;")
             self._addKerning(lines, self.rightClassKerning, enum=True)
-        if self.leftClassKerning:
+        if self.classPairKerning:
             lines.append("    subtable;")
             self._addKerning(lines, self.classPairKerning)
         lines.append("} kern;")
@@ -84,7 +85,7 @@ class KernFeatureWriter(AbstractFeatureWriter):
     def _collectFeaClasses(self):
         """Parse glyph classes from existing OTF syntax."""
 
-        parser.parseFeatures(self, font.features.text)
+        parser.parseFeatures(self, self.featxt)
 
     def _collectFeaClassKerning(self):
         """Set up class kerning rules from OTF glyph class definitions.

--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -166,7 +166,7 @@ class KernFeatureWriter(AbstractFeatureWriter):
             nlGlyphs = []
             for lGlyph in lGlyphs:
                 pair = lGlyph, rGlyph
-                if pair not in seen or seen[pair] == val:
+                if pair not in seen:
                     nlGlyphs.append(lGlyph)
                     seen[pair] = val
             if nlGlyphs != lGlyphs:
@@ -179,7 +179,7 @@ class KernFeatureWriter(AbstractFeatureWriter):
             nrGlyphs = []
             for rGlyph in rGlyphs:
                 pair = lGlyph, rGlyph
-                if pair not in seen or seen[pair] == val:
+                if pair not in seen:
                     nrGlyphs.append(rGlyph)
                     seen[pair] = val
             if nrGlyphs != rGlyphs:
@@ -194,7 +194,7 @@ class KernFeatureWriter(AbstractFeatureWriter):
             for lGlyph in lGlyphs:
                 for rGlyph in rGlyphs:
                     pair = lGlyph, rGlyph
-                    if pair not in seen or seen[pair] == val:
+                    if pair not in seen:
                         nlGlyphs.add(lGlyph)
                         nrGlyphs.add(rGlyph)
                         seen[pair] = val

--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -26,8 +26,8 @@ class KernFeatureWriter(AbstractFeatureWriter):
         self.kerning = font.kerning
         self.groups = font.groups
 
-        self.leftClasses = []
-        self.rightClasses = []
+        self.leftClasses = {}
+        self.rightClasses = {}
 
         self.glyphPairKerning = {}
         self.leftClassKerning = {}
@@ -42,11 +42,10 @@ class KernFeatureWriter(AbstractFeatureWriter):
     def classDefinition(self, name, contents):
         """Store a class definition as either a left- or right-hand class."""
 
-        info = (name, contents)
         if self._isGlyphClass(self.leftFeaClassRe, name):
-            self.leftClasses.append(info)
+            self.leftClasses[name] = contents
         elif self._isGlyphClass(self.rightFeaClassRe, name):
-            self.rightClasses.append(info)
+            self.rightClasses[name] = contents
 
     def _addGlyphClasses(self, lines):
         """Add glyph classes for the input font's groups."""
@@ -68,11 +67,11 @@ class KernFeatureWriter(AbstractFeatureWriter):
         the kerning values associated with that class.
         """
 
-        for leftName, leftContents in self.leftClasses:
+        for leftName, leftContents in self.leftClasses.items():
             leftKey = leftContents[0]
 
             # collect rules with two classes
-            for rightName, rightContents in self.rightClasses:
+            for rightName, rightContents in self.rightClasses.items():
                 rightKey = rightContents[0]
                 pair = leftKey, rightKey
                 kerningVal = self.kerning[pair]
@@ -87,7 +86,7 @@ class KernFeatureWriter(AbstractFeatureWriter):
                 self.kerning.remove(pair)
 
         # collect rules with left glyph and right class
-        for rightName, rightContents in self.rightClasses:
+        for rightName, rightContents in self.rightClasses.items():
             rightKey = rightContents[0]
             for pair, kerningVal in self.kerning.getRight(rightKey):
                 self.rightClassKerning[pair[0], rightName] = kerningVal


### PR DESCRIPTION
This addresses a few issues with kern feature generation:
- 0b308b02556c5658fcad918add3d3798b5411fcd, da2f5aa2f4390bb035a74577587f95b894bcb3a4 remove duplicate kerning rules, which are not allowed by feaLib
- 31ef3ff5ab53231be406674c1148804fd750d979, dab2efe78e394cb16438a4ba4398bfbf6e04e34b take some improvements from @anthrotype in #7 including fixing #10 (cc @adrientetar).

It's not addressing RTL kerning, yet.